### PR TITLE
Add GitHub Skills activity to activities database

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -75,6 +75,13 @@ activities = {
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
     }
+    ,
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program.",
+        "schedule": "Thursdays, 4:00 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
+    }
 }
 
 


### PR DESCRIPTION
This pull request adds the missing "GitHub Skills" activity to the in-memory activities database, making it available for registration and visible in the frontend activities list. This addresses the urgent request to support the new GitHub Skills program for students.